### PR TITLE
Add CMake, *nix support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.6)
+
+project(SoxFilter VERSION 2.1)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+include(FindPkgConfig)
+if(MINGW)
+    pkg_search_module(AVISYNTH avisynth>=3.5.0)
+    if(AVISYNTH_FOUND)
+        include_directories(${AVISYNTH_INCLUDE_DIRS})
+    else()
+        # the path on Windows itself, outside of pkg-config
+        include_directories($ENV{AVISYNTH_SDK_PATH}/include)
+    endif()
+else()
+    pkg_search_module(AVISYNTH REQUIRED avisynth>=3.5.0)
+    include_directories(${AVISYNTH_INCLUDE_DIRS})
+endif()
+
+add_library(SoxFilter SHARED SoxFilter/soxfilter.cpp)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -I. -Wall -O3 -ffast-math -fno-math-errno -fomit-frame-pointer")
+
+target_link_libraries(SoxFilter sox)
+
+include(GNUInstallDirs)
+install(TARGETS SoxFilter
+        LIBRARY DESTINATION lib/avisynth)
+
+# uninstall target
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)

--- a/SoxFilter/soxfilter.cpp
+++ b/SoxFilter/soxfilter.cpp
@@ -37,16 +37,20 @@
 */
 
 
-#include "avisynth.h"
 // needs /Zc:__cplusplus on MSVC:
-#include "avs/filesystem.h"
 #ifdef AVS_WINDOWS
+#include "avisynth.h"
 #include "avs/win.h"
-#else
-#include "avs/posix.h"
-#endif
-#include "../libsox/sox.h"
+#include "avs/filesystem.h"
 #include "avs/minmax.h"
+#include "../libsox/sox.h"
+#else
+#include <avisynth.h>
+#include <avs/posix.h>
+#include <avs/filesystem.h>
+#include <avs/minmax.h>
+#include <sox.h>
+#endif
 #include <vector>
 #include <algorithm>
 #include <string>

--- a/SoxFilter/soxfilter.cpp
+++ b/SoxFilter/soxfilter.cpp
@@ -808,11 +808,11 @@ void __stdcall SoxFilter::GetAudio(void* buf, int64_t start, int64_t count, IScr
     
     int sox_errno = sox_flow_effects(chain, NULL, NULL);
 
-    _RPT4(0, "SoxFilter::GetAudio: AFTER flow debug1/2: output_sample_counter_mul_chn=%d total_needed_sample_count_mul_chn=%d next_start=%d\n",
+    _RPT3(0, "SoxFilter::GetAudio: AFTER flow debug1/2: output_sample_counter_mul_chn=%d total_needed_sample_count_mul_chn=%d next_start=%d\n",
       (int)out_info.output_sample_counter,
       (int)out_info.sample_count_getaudio,
       (int)out_info.remaining_precalculated_samples % vi.AudioChannels());
-    _RPT3(0, "SoxFilter::GetAudio: AFTER flow debug2/2: samplecount=%d samplecount_mul_chn=%d mod=%d\n",
+    _RPT4(0, "SoxFilter::GetAudio: AFTER flow debug2/2: samplecount=%d samplecount_mul_chn=%d mod=%d\n",
       (int)out_info.remaining_precalculated_samples / vi.AudioChannels(),
       (int)out_info.remaining_precalculated_samples,
       (int)out_info.remaining_precalculated_samples % vi.AudioChannels(),

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)


### PR DESCRIPTION
Figured it would be pretty simple to do.

The only iffy one is that last commit, because without that swapping of the two _RPT instances, it errors out like this:
```
$ make
[ 50%] Building CXX object CMakeFiles/SoxFilter.dir/SoxFilter/soxfilter.cpp.o
/home/qyot27/mpv-build-deps/SoxFilter/SoxFilter/soxfilter.cpp:814:73: error: macro "_RPT4" requires 6 arguments, but only 5 given
  814 |    (int)out_info.remaining_precalculated_samples % vi.AudioChannels());
      |                                                                      ^

In file included from /home/qyot27/mpv-build-deps/SoxFilter/SoxFilter/soxfilter.cpp:48:
/usr/local/include/avisynth/avisynth.h:135: note: macro "_RPT4" defined here
  135 |   #define _RPT4(a,b,c,d,e,f) ((void)0)
      | 
/home/qyot27/mpv-build-deps/SoxFilter/SoxFilter/soxfilter.cpp:819:45: error: macro "_RPT3" passed 6 arguments, but takes just 5
  819 |       (int)avs_in_info.inputbuf.next_start());
      |                                             ^
/usr/local/include/avisynth/avisynth.h:134: note: macro "_RPT3" defined here
  134 |   #define _RPT3(a,b,c,d,e) ((void)0)
      | 
/home/qyot27/mpv-build-deps/SoxFilter/SoxFilter/soxfilter.cpp: In function ‘void DebugFilterInfos(sox_effects_chain_t*)’:
/home/qyot27/mpv-build-deps/SoxFilter/SoxFilter/soxfilter.cpp:651:21: warning: unused variable ‘current_flow_effect’ [-Wunused-variable]
  651 |       sox_effect_t* current_flow_effect = &chain->effects[i][eff];
      |                     ^~~~~~~~~~~~~~~~~~~
/home/qyot27/mpv-build-deps/SoxFilter/SoxFilter/soxfilter.cpp: In member function ‘virtual void SoxFilter::GetAudio(void*, int64_t, int64_t, IScriptEnvironment*)’:
/home/qyot27/mpv-build-deps/SoxFilter/SoxFilter/soxfilter.cpp:811:5: error: ‘_RPT4’ was not declared in this scope
  811 |     _RPT4(0, "SoxFilter::GetAudio: AFTER flow debug1/2: output_sample_counter_mul_chn=%d total_needed_sample_count_mul_chn=%d next_start=%d\n",
      |     ^~~~~
/home/qyot27/mpv-build-deps/SoxFilter/SoxFilter/soxfilter.cpp:815:5: error: ‘_RPT3’ was not declared in this scope
  815 |     _RPT3(0, "SoxFilter::GetAudio: AFTER flow debug2/2: samplecount=%d samplecount_mul_chn=%d mod=%d\n",
      |     ^~~~~
/home/qyot27/mpv-build-deps/SoxFilter/SoxFilter/soxfilter.cpp: At global scope:
/home/qyot27/mpv-build-deps/SoxFilter/SoxFilter/soxfilter.cpp:642:13: warning: ‘void DebugFilterInfos(sox_effects_chain_t*)’ defined but not used [-Wunused-function]
  642 | static void DebugFilterInfos(sox_effects_chain_t* chain)
      |             ^~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/SoxFilter.dir/build.make:76: CMakeFiles/SoxFilter.dir/SoxFilter/soxfilter.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:84: CMakeFiles/SoxFilter.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

Complaining that _RPT4 needing 6 arguments but got 5, and _RPT3 needing 5 arguments but got 6, so it looks like that might have just been an oversight and they needed to be swapped anyway?  Unless MSVC treats that in some special way.

I was able to build and confirm that `libSoxFilter.so` is working with the **bandpass** example provided on the AviSynth Wiki.

It is also set up to simply use the system version of the sox.h header, since Ubuntu has libsox in its repositories.  The includes for libsox and AviSynth were just condensed into the OS includes branch so that on Windows, it'll use the local copies as instructed by the README, while elsewhere it'll do the normal *nix thing and just use pkg-config or find it on the system (I didn't try to detect libsox with pkg-config, that could be something for down the line).